### PR TITLE
[1.0.2] Adjust lodash version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.2] - 2020-06-09
+### Updated
+- Adjust lodash version
+
 ## [1.0.1] - 2018-08-23
 ### Updated
 - Added test case for tipsi/remove-event-listener when callee is Identifier

--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 * [tipsi/remove-event-listener](/docs/rules/remove-event-listener.md)
 
 ## Changelog
+[[1.0.2] - 2020-06-09](/CHANGELOG.md#102---2020-06-09)
+
 [[1.0.1] - 2018-08-23](/CHANGELOG.md#101---2018-08-23)
 
 [[1.0.0] - 2018-08-23](/CHANGELOG.md#100---2018-08-23)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tipsi",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1231,9 +1231,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw=="
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-tipsi",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Custom Tipsi rules for eslint",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/isnifer/eslint-plugin-tipsi#readme",
   "dependencies": {
-    "lodash": "4.17.10"
+    "lodash": "~4.17.10"
   },
   "devDependencies": {
     "babel-eslint": "8.2.6",


### PR DESCRIPTION
We're using this package in our project but since it is locked to lodash version `4.17.10` and we primarily use `4.17.14` it causes multiple entries in our yarn.lock that would be nice to flatten down

This PR changes the lodash version to allow lodash versions from 4.17.10 to <4.18.0 instead of strictly using 4.17.10